### PR TITLE
fix: use string splicing instead of path resolve to solve the problem of arbitrary path matchers under windows

### DIFF
--- a/src/main/java/run/halo/gradle/watch/WatchTask.java
+++ b/src/main/java/run/halo/gradle/watch/WatchTask.java
@@ -17,7 +17,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.gradle.StartParameter;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.pattern.PatternMatcher;
@@ -165,7 +164,7 @@ public class WatchTask extends DockerStartContainer {
 
     String excludePattern(String pattern) {
         Path projectPath = getProject().getProjectDir().toPath();
-        return projectPath.resolve(StringUtils.removeStart(pattern, "/")).toString();
+        return projectPath + "/" + pattern;
     }
 
     private File getPluginBuildFile() {


### PR DESCRIPTION
修复 windows 下因路径包含 `*` 而不能正常 watch 的问题
Fixes https://github.com/halo-sigs/halo-gradle-plugin/issues/9
```release-note
None
```