### PR TITLE
chore: automate Maven publishing using GitHub Actions release tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,12 +31,7 @@ jobs:
       - name: Extract version from GitHub tag
         id: extract_version
         run: |
-          TAG_NAME=${{ github.ref_name }}
-          if [[ $TAG_NAME == v* ]]; then
-            VERSION=${TAG_NAME:1}
-          else
-            VERSION=$TAG_NAME
-          fi
+          version=${{ github.event.release.tag_name }}
           echo "Extracted Version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,50 @@
+name: Publish Halo Devtools Gradle Plugin to Maven
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Extract version from GitHub tag
+        id: extract_version
+        run: |
+          TAG_NAME=${{ github.ref_name }}
+          if [[ $TAG_NAME == v* ]]; then
+            VERSION=${TAG_NAME:1}
+          else
+            VERSION=$TAG_NAME
+          fi
+          echo "Extracted Version: $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -Pversion=${{ env.VERSION }}
+
+      - name: Publish to Maven
+        env:
+          OSSR_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          OSSR_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        run: ./gradlew publish -Pversion=${{ env.VERSION }}

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,8 @@ publishing {
     repositories {
         maven {
             name = "SonatypePackages"
-            def releasesRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/releases/'
-            def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('-SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            url = version.endsWith('-SNAPSHOT') ? 'https://s01.oss.sonatype.org/content/repositories/snapshots/' :
+                    'https://s01.oss.sonatype.org/content/repositories/releases/'
             credentials {
                 username = project.findProperty("ossr.user") ?: System.getenv("OSSR_USERNAME")
                 password = project.findProperty("ossr.password") ?: System.getenv("OSSR_PASSWORD")
@@ -35,6 +34,37 @@ publishing {
     publications {
         ossr(MavenPublication) {
             from(components.java)
+            groupId = 'run.halo.gradle'
+            artifactId = 'A plugin devtools for Halo'
+            version = project.hasProperty('version') ? project.property('version') : 'unspecified'
+
+            pom {
+                name = 'HaloPluginDevtools'
+                description = 'Halo Gradle Plugin'
+                url = 'https://github.com/halo-sigs/halo-gradle-plugin'
+
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'guqing'
+                        name = 'guqing'
+                        email = 'i@guqing.email'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/halo-sigs/halo-gradle-plugin.git'
+                    developerConnection = 'scm:git:ssh://git@github.com:/halo-sigs/halo-gradle-plugin.git'
+                    url = 'https://github.com/halo-sigs/halo-gradle-plugin'
+                }
+            }
+
             versionMapping {
                 usage('java-api') {
                     fromResolutionOf('runtimeClasspath')
@@ -49,10 +79,10 @@ publishing {
 
 gradlePlugin {
     plugins {
-        pluginDevelopment {
+        create('HaloPluginDevtools') {
             id = 'run.halo.plugin.devtools'
-            displayName = "Halo Gradle Plugin"
-            description = "Halo Gradle Plugin For Plugin Developer"
+            displayName = 'Halo Plugin Devtools'
+            description = 'A plugin devtools for Halo'
             implementationClass = 'run.halo.gradle.HaloDevtoolsPlugin'
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.10-SNAPSHOT
+version=0.2.0-SNAPSHOT

--- a/src/main/java/run/halo/gradle/docker/DockerCopyFileToContainer.java
+++ b/src/main/java/run/halo/gradle/docker/DockerCopyFileToContainer.java
@@ -15,6 +15,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import run.halo.gradle.utils.Assert;
@@ -42,7 +43,7 @@ public class DockerCopyFileToContainer extends DockerExistingContainer {
     /**
      * Tar file we will copy into container
      */
-    @Input
+    @InputFile
     @Optional
     final RegularFileProperty tarFile = getProject().getObjects().fileProperty();
 


### PR DESCRIPTION
### What this PR does?
添加了GitHub Actions工作流以便在 Release 后自动将 Gradle 插件发布到 Maven Central

测试构建结果：https://github.com/guqing/halo-gradle-plugin/actions/runs/10210126780/job/28249234250

```release-note
添加 GitHub Actions工作流以便在 Release 后自动将 Gradle 插件发布到 Maven Central
```
