### PR TITLE
fix: wrong artifactId in workflow file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ publishing {
         ossr(MavenPublication) {
             from(components.java)
             groupId = 'run.halo.gradle'
-            artifactId = 'A plugin devtools for Halo'
+            artifactId = 'halo-gradle-plugin'
             version = project.hasProperty('version') ? project.property('version') : 'unspecified'
 
             pom {


### PR DESCRIPTION
### What this PR does?
修复错误的 artifactId 配置

see #https://github.com/guqing/halo-gradle-plugin/actions/runs/10213943611/job/28260370740

```release-note
None
```