### PR TITLE
refactor: adapt to Halo disabling basic auth by default in production

### DIFF
--- a/src/main/java/run/halo/gradle/utils/HaloServerConfigure.java
+++ b/src/main/java/run/halo/gradle/utils/HaloServerConfigure.java
@@ -50,6 +50,9 @@ public class HaloServerConfigure {
                       no-cache: true
                     use-last-modified: false
             halo:
+              security:
+                basic-auth:
+                  disabled: false
               external-url: {externalUrl}
               plugin:
                 runtime-mode: development


### PR DESCRIPTION
### What this PR does?
Halo 默认禁用了 basic auth 因此这里需要显示配置启用它，避免开发插件时无法正确调用 API

```release-note
None
```