### PR TITLE
feat: support displaying API docs in haloServer task using openApi config

### DIFF
--- a/src/main/java/run/halo/gradle/openapi/AbstractOpenApiDocsTask.java
+++ b/src/main/java/run/halo/gradle/openapi/AbstractOpenApiDocsTask.java
@@ -1,0 +1,118 @@
+package run.halo.gradle.openapi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import run.halo.gradle.docker.DockerExistingImage;
+import run.halo.gradle.extension.HaloPluginExtension;
+import run.halo.gradle.utils.YamlUtils;
+
+@Getter
+public abstract class AbstractOpenApiDocsTask extends DockerExistingImage {
+
+    @Internal
+    private final HaloPluginExtension pluginExtension =
+        getProject().getExtensions().getByType(HaloPluginExtension.class);
+
+    @Input
+    protected final MapProperty<String, String> groupedApiMappings = getProject().getObjects()
+        .mapProperty(String.class, String.class);
+
+    @Input
+    private final Property<String> apiDocsVersion =
+        getProject().getObjects().property(String.class);
+
+    @Internal
+    private final Property<String> apiDocsUrl = getProject().getObjects().property(String.class);
+
+    @Internal
+    protected final DirectoryProperty outputDir = getProject().getObjects().directoryProperty();
+
+    @Internal
+    private final List<SpringDocGroupConfig> springDocGroupConfigs = new ArrayList<>();
+
+    public AbstractOpenApiDocsTask() {
+        var openApi = pluginExtension.getOpenApi();
+        openApi.getGroupingRules().getAsMap().forEach((group, config) -> {
+            springDocGroupConfigs.add(SpringDocGroupConfig.builder()
+                .group(group)
+                .displayName(config.getDisplayName().get())
+                .pathsToMatch(config.getPathsToMatch().get())
+                .pathsToExclude(config.getPathsToExclude().get())
+                .build());
+        });
+        groupedApiMappings.convention(openApi.getGroupedApiMappings());
+        apiDocsUrl.convention(openApi.getApiDocsUrl());
+        outputDir.convention(openApi.getOutputDir());
+        apiDocsVersion.convention(openApi.getApiDocsVersion());
+    }
+
+    protected JsonNode generateSpringDocApplicationConfig() {
+        var springDocYaml = generateSpringDocConfigString(this.springDocGroupConfigs);
+        if (StringUtils.isBlank(springDocYaml)) {
+            return JsonNodeFactory.instance.missingNode();
+        }
+        return YamlUtils.read(springDocYaml, JsonNode.class);
+    }
+
+    protected static String generateSpringDocConfigString(@Nonnull
+    List<SpringDocGroupConfig> configs) {
+        if (configs.isEmpty()) {
+            return null;
+        }
+        StringBuilder yamlBuilder = new StringBuilder();
+        yamlBuilder.append("springdoc:\n")
+            .append("  group-configs:\n");
+        for (var entry : configs) {
+            var group = entry.group();
+            var pathsToMatch = entry.pathsToMatch;
+            var pathsToExclude = entry.pathsToExclude();
+            var displayName = entry.displayName();
+            yamlBuilder.append("    - group: ").append(group).append("\n")
+                .append("      displayName: ").append(displayName).append("\n");
+
+            if (!pathsToMatch.isEmpty()) {
+                yamlBuilder.append("      paths-to-match:\n");
+                for (String path : pathsToMatch) {
+                    yamlBuilder.append("        - ").append(path).append("\n");
+                }
+            }
+
+            if (!pathsToExclude.isEmpty()) {
+                yamlBuilder.append("      paths-to-exclude:\n");
+                for (String path : pathsToExclude) {
+                    yamlBuilder.append("        - ").append(path).append("\n");
+                }
+            }
+        }
+        return yamlBuilder.toString();
+    }
+
+    @Builder
+    protected record SpringDocGroupConfig(String group, String displayName,
+                                          List<String> pathsToMatch,
+                                          List<String> pathsToExclude) {
+        public SpringDocGroupConfig {
+            if (StringUtils.isBlank(displayName)) {
+                displayName = group;
+            }
+            if (pathsToMatch == null) {
+                pathsToMatch = Collections.emptyList();
+            }
+            if (pathsToExclude == null) {
+                pathsToExclude = Collections.emptyList();
+            }
+        }
+    }
+}

--- a/src/test/java/run/halo/gradle/openapi/AbstractOpenApiDocsTaskTest.java
+++ b/src/test/java/run/halo/gradle/openapi/AbstractOpenApiDocsTaskTest.java
@@ -6,25 +6,25 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link OpenApiDocsGeneratorTask}.
+ * Tests for {@link AbstractOpenApiDocsTask}.
  *
  * @author guqing
- * @since 0.0.10
+ * @since 0.4.0
  */
-class OpenApiDocsGeneratorTaskTest {
+class AbstractOpenApiDocsTaskTest {
 
     @Test
-    void generateSpringDocConfigStringTest() {
-        var result = OpenApiDocsGeneratorTask.generateSpringDocConfigString(List.of());
+    void generateSpringDocApplicationConfig() {
+        var result = AbstractOpenApiDocsTask.generateSpringDocConfigString(List.of());
         assertThat(result).isNull();
 
-        var config = OpenApiDocsGeneratorTask.SpringDocGroupConfig.builder()
+        var config = AbstractOpenApiDocsTask.SpringDocGroupConfig.builder()
             .group("postShareLinkExtensionV1alpha1Api")
             .displayName("Extension API for Post Share Link")
             .pathsToMatch(List.of("/api/v1alpha1/share/**"))
             .pathsToExclude(List.of("/api/v1alpha1/do-not-share/**"))
             .build();
-        result = OpenApiDocsGeneratorTask.generateSpringDocConfigString(List.of(config));
+        result = AbstractOpenApiDocsTask.generateSpringDocConfigString(List.of(config));
         assertThat(result).isEqualTo("""
             springdoc:
               group-configs:

--- a/src/test/java/run/halo/gradle/utils/HaloServerConfigureTest.java
+++ b/src/test/java/run/halo/gradle/utils/HaloServerConfigureTest.java
@@ -16,11 +16,11 @@ class HaloServerConfigureTest {
 
     @Test
     void mergeUserDefinedTest() throws JSONException, JsonProcessingException {
-        var configure = HaloServerConfigure.builder()
+        var applicationJson = HaloServerConfigure.builder()
             .workDir("/root/.halo2")
             .fixedPluginPath("/fake-project")
-            .build();
-        var applicationJson = configure.getServerConfig();
+            .build()
+            .toApplicationJsonString();
         JSONAssert.assertEquals("""
             {
                 "server": {
@@ -85,7 +85,7 @@ class HaloServerConfigureTest {
                     }
                 }
             }
-            """, applicationJson.toPrettyString(), true);
+            """, applicationJson, true);
 
         var userDefined = YamlUtils.mapper.readValue("""
             server:
@@ -97,7 +97,12 @@ class HaloServerConfigureTest {
               external-url: http://localhost:8080
               work-dir: /root/.halo-dev2
             """, JsonNode.class);
-        var newApplicationJsonString = configure.mergeWithUserConfigAsJson(userDefined);
+        var newApplicationJsonString = HaloServerConfigure.builder()
+            .workDir("/root/.halo2")
+            .fixedPluginPath("/fake-project")
+            .otherConfig(userDefined)
+            .build()
+            .toApplicationJsonString();
         JSONAssert.assertEquals("""
             {
                 "server": {


### PR DESCRIPTION
### What this PR does?
haloServer 和 watch 任务支持根据 `haloPlugin.openApi` 配置在 swagger-ui 中显示 API 文档

```release-note
haloServer 和 watch 任务支持根据 `haloPlugin.openApi` 配置在 swagger-ui 中显示 API 文档
```