### PR TITLE
fix: no value has been configured for additionalApplicationConfig

### DIFF
--- a/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
+++ b/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
@@ -68,6 +68,7 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
     final DirectoryProperty pluginWorkplaceDir = getProject().getObjects().directoryProperty();
 
     @InputFile
+    @Optional
     @Getter
     final RegularFileProperty additionalApplicationConfig =
         getProject().getObjects().fileProperty();


### PR DESCRIPTION
### What this PR does?
修复没有自定义配置时无法使用 haloServer 的问题

此问题由 #32 导致

```release-note
None
```