### PR TITLE
Upgrade ASM to 9.8 to add Java 21 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ ext {
     jackjson = '2.14.0'
     lang3 = '3.12.0'
     semver4j = '0.9.0'
-    asm = '9.4'
+    asm = '9.8'
     dockerJava = '3.3.0'
     jsonPatch = '1.13'
     openApiGenerator = '7.7.0'


### PR DESCRIPTION
```java
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 65
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:287)
        at run.halo.gradle.PluginComponentsIndexTask.generate(PluginComponentsIndexTask.java:56)
```

See https://asm.ow2.io/versions.html for more.
```release-note
升级 ASM 至 9.8 以支持 Java 21
```

