### PR TITLE
Refactor publishing Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'java-gradle-plugin'
-    id 'maven-publish'
+    id 'signing'
+    id 'com.gradle.plugin-publish' version '1.3.1'
     id "io.freefair.lombok" version "8.13.1"
 }
 
@@ -22,70 +22,29 @@ repositories {
 publishing {
     repositories {
         maven {
-            name = "SonatypePackages"
-            url = version.endsWith('-SNAPSHOT') ? 'https://s01.oss.sonatype.org/content/repositories/snapshots/' :
-                    'https://s01.oss.sonatype.org/content/repositories/releases/'
-            credentials {
-                username = project.findProperty("ossr.user") ?: System.getenv("OSSR_USERNAME")
-                password = project.findProperty("ossr.password") ?: System.getenv("OSSR_PASSWORD")
-            }
-        }
-    }
-    publications {
-        ossr(MavenPublication) {
-            from(components.java)
-            groupId = 'run.halo.gradle'
-            artifactId = 'halo-gradle-plugin'
-            version = project.hasProperty('version') ? project.property('version') : 'unspecified'
-
-            pom {
-                name = 'HaloPluginDevtools'
-                description = 'Halo Gradle Plugin'
-                url = 'https://github.com/halo-sigs/halo-gradle-plugin'
-
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'guqing'
-                        name = 'guqing'
-                        email = 'i@guqing.email'
-                    }
-                }
-
-                scm {
-                    connection = 'scm:git:git://github.com/halo-sigs/halo-gradle-plugin.git'
-                    developerConnection = 'scm:git:ssh://git@github.com:/halo-sigs/halo-gradle-plugin.git'
-                    url = 'https://github.com/halo-sigs/halo-gradle-plugin'
-                }
-            }
-
-            versionMapping {
-                usage('java-api') {
-                    fromResolutionOf('runtimeClasspath')
-                }
-                usage('java-runtime') {
-                    fromResolutionResult()
-                }
-            }
+            name = "internal"
+            url = layout.buildDirectory.dir('repo/internal')
         }
     }
 }
 
 gradlePlugin {
+    website = 'https://github.com/halo-sigs/halo-gradle-plugin'
+    vcsUrl = 'https://github.com/halo-sigs/halo-gradle-plugin.git'
+
     plugins {
-        create('HaloPluginDevtools') {
+        create('haloPluginDevtoolsPlugin') {
             id = 'run.halo.plugin.devtools'
             displayName = 'Halo Plugin Devtools'
-            description = 'A plugin devtools for Halo'
+            description = 'A plugin devtools for Halo plugin'
             implementationClass = 'run.halo.gradle.HaloDevtoolsPlugin'
+            tags.addAll('halo', 'java', 'devtools')
         }
     }
+}
+
+signing {
+    sign publishing.publications
 }
 
 ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.5.1-SNAPSHOT
+version=0.6.0-SNAPSHOT

--- a/src/main/java/run/halo/gradle/role/RequestInfoFactory.java
+++ b/src/main/java/run/halo/gradle/role/RequestInfoFactory.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * @see
- * <a href="https://github.com/halo-dev/halo/blob/17e9f2be1f63cbfe328d806987a284c702be79fe/application/src/main/java/run/halo/app/security/authorization/RequestInfoFactory.java#L17>Halo RequestInfoFactory</a>
+ * <a href="https://github.com/halo-dev/halo/blob/17e9f2be1f63cbfe328d806987a284c702be79fe/application/src/main/java/run/halo/app/security/authorization/RequestInfoFactory.java#L17">Halo RequestInfoFactory</a>
  */
 public class RequestInfoFactory {
     public static final RequestInfoFactory INSTANCE =


### PR DESCRIPTION
This PR refactors publishing Gradle plugin according to <https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#publishing_portal>.

After this PR, I will publish the plugin v0.6.0 into Gradle Plugin Portal instead of maven central.

```release-note
None
```

